### PR TITLE
ug-887 Accessibility improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,11 +29,11 @@ function attachButton() {
 function attachDropdown() {
 	const dropdownMarkup = `
 		<ul class="n-myft-dropdown-menu" onclick=event.stopPropagation() role="menu">
-			<li class="n-myft-dropdown-list" role="menuitem"><a href="/myft/following" tabindex="-1" data-trackable="myft-dropdown-topic-feed">Topic Feed</a></li>
-			<li class="n-myft-dropdown-list" role="menuitem"><a href="/myft/saved-articles" tabindex="-1" data-trackable="myft-dropdown-saved-articles">Saved Articles</a></li>
-			<li class="n-myft-dropdown-list" role="menuitem"><a href="/myft/explore" tabindex="-1" data-trackable="myft-dropdown-explore-feed">Explore Feed</a></li>
-			<li class="n-myft-dropdown-list" role="menuitem"><a href="/newsletters" tabindex="-1" data-trackable="myft-dropdown-newsletters">Newsletters</a></li>
-			<li class="n-myft-dropdown-list" role="menuitem"><a href="/myft/alerts" tabindex="-1" data-trackable="myft-dropdown-contact-preferences">Contact Preferences</a></li>
+			<li class="n-myft-dropdown-list" role="none"><a href="/myft/following" tabindex="-1" data-trackable="myft-dropdown-topic-feed" role="menuitem">Topic Feed</a></li>
+			<li class="n-myft-dropdown-list" role="none"><a href="/myft/saved-articles" tabindex="-1" data-trackable="myft-dropdown-saved-articles" role="menuitem">Saved Articles</a></li>
+			<li class="n-myft-dropdown-list" role="none"><a href="/myft/explore" tabindex="-1" data-trackable="myft-dropdown-explore-feed" role="menuitem">Explore Feed</a></li>
+			<li class="n-myft-dropdown-list" role="none"><a href="/newsletters" tabindex="-1" data-trackable="myft-dropdown-newsletters" role="menuitem">Newsletters</a></li>
+			<li class="n-myft-dropdown-list" role="none"><a href="/myft/alerts" tabindex="-1" data-trackable="myft-dropdown-contact-preferences" role="menuitem">Contact Preferences</a></li>
 		</ul>`;
 	const dropdown = document.createElement('span');
 	dropdown.innerHTML = dropdownMarkup.trim();

--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
   },
   "peerDependencies": {
     "@financial-times/o-colors": "^6.4.2",
-    "@financial-times/o-header": "^10.0.1",
-    "@financial-times/o-icons": "^7.4.0",
-    "@financial-times/o-tracking": "^4.3.2",
-    "@financial-times/o-typography": "^7.3.2",
+    "@financial-times/o-header": "^9.2.3 || ^10.0.1",
+    "@financial-times/o-icons": "^7.2.1",
+    "@financial-times/o-tracking": "^4.3.0",
+    "@financial-times/o-typography": "^7.3.1",
     "@financial-times/o-visual-effects": "^4.2.0",
     "@financial-times/o-utils": "^2.1.1"
   }


### PR DESCRIPTION
### Description
This PR includes 2 minor changes:

1. Following advice from Dan Jolley at DAC, changing the roles on the elements in the dropdown menu, see [Aria Best Practices](https://www.w3.org/WAI/ARIA/apg/example-index/menu-button/menu-button-links)
2. Widening the peer dependencies, as next-article and next-homepage are running different versions of origami components.

### Ticket
This falls under [ug-887](https://financialtimes.atlassian.net/browse/UG-887)

### Screenshots

Before
<img width="976" alt="Screenshot 2022-06-29 at 10 40 28" src="https://user-images.githubusercontent.com/54366961/176407809-1c2b6251-0d7f-485e-8e10-3acf524bd3cb.png">

After
<img width="1049" alt="Screenshot 2022-06-29 at 10 49 32" src="https://user-images.githubusercontent.com/54366961/176407442-234e1865-c761-466e-86c7-7289712a3ed8.png">

### How do I test this code?

For point 1:
1. clone the repo locally and checkout the branch. Run `npm run demo`
2. Open http://localhost:3000 and inspect the dropdown element. It should match the 'after' screenshot above.

For point 2:
1. locally in `next-article` and `next-home-page`,  run `npm i "https://github.com/Financial-Times/n-myft-dropdown.git#accessibility-improvements"`. It should install succesfully.


### Reminder
Have you completed these common tasks? (remove those that don't apply)

- [x] **Manual Testing** checked the expected functionality
- [x] **Guidance for reviewer** communicated expected changes / behaviour
- [x] **Accessibility** checked for screen readers and contrast

### How we will review this PR
Our team uses [conventional comments](https://conventionalcomments.org/) to provide feedback.