### PR TITLE
Avoid loading fonts

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -3,6 +3,9 @@ $system-code: 'n-myft-dropdown';
 @import '@financial-times/o-header/main';
 @include oHeader();
 
+@import '@financial-times/o-fonts/main';
+@include oFonts();
+
 @import '../../main';
 
 html {

--- a/main.scss
+++ b/main.scss
@@ -5,8 +5,11 @@ $system-code: 'n-myft-dropdown';
 @import "@financial-times/o-colors/main";
 @include oColors();
 
+$o-typography-load-fonts: false;
 @import '@financial-times/o-typography/main';
-@include oTypography();
+@include oTypography((
+	'links': true,
+));
 
 @import '@financial-times/o-grid/main';
 @import '@financial-times/o-visual-effects/main';


### PR DESCRIPTION
### Description
Loading fonts using o-typography from this component was causing issues on the consuming apps. The $o-typography-load-fonts variable is set to avoid loading the fonts


### Screenshots

| Before | After |
| ------ | ----- |
|<img width="352" alt="Screenshot 2022-07-01 at 16 05 08" src="https://user-images.githubusercontent.com/7011304/176920986-1a282e47-bf01-49a0-9c73-7ffbb7a818eb.png"> |<img width="332" alt="Screenshot 2022-07-01 at 16 07 18" src="https://user-images.githubusercontent.com/7011304/176921043-6cf45e9a-8a7a-427c-983d-846514ba8988.png">|


### How do I test this code?

1. Clone the branch locally
2. Run `npm link` from the command line
3. Clone next-home-page locally
4. Run `npm link n-myft-dropdown` on next-home-page
5. Run next-home-page locally with `npm start`
6. Go to `http://localhost:3000` and check that the article links with `font-weigth: semibold` are showing properly

### Reminder
Have you completed these common tasks? (remove those that don't apply)

- [x] **Manual Testing** checked the expected functionality
- [x] **Guidance for reviewer** communicated expected changes / behaviour


### How we will review this PR
Our team uses [conventional comments](https://conventionalcomments.org/) to provide feedback.