### PR TITLE
ug-928 focus first item on menu open

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,10 @@ function setExpandedAttributes(button, expanded) {
 	}
 	const linkItems = button.nextElementSibling.querySelectorAll('a');
 	const tabValue = expanded ? 0 : -1;
-	linkItems.forEach((item) => {
+	linkItems.forEach((item, index) => {
+		if (index === 0 && expanded) {
+			item.focus();
+		}
 		item.setAttribute('tabindex', tabValue);
 	});
 }


### PR DESCRIPTION
### Description
We received feedback from our accessibility consultant that we needed to focus on the first menu item when the myFT button was selected when using a keyboard so that it (and the rest of the menu) could be announced by a screen reader.
see the example on [this page](https://www.w3.org/WAI/ARIA/apg/example-index/menu-button/menu-button-actions).

### Ticket
[ug-928](https://financialtimes.atlassian.net/browse/UG-928)

### Screenshots

** Before **
It's hard to see but there's a tab needed to get into the menu.
https://user-images.githubusercontent.com/54366961/177587877-29bb0146-12a4-4df5-9d3d-13220146df1c.mov

** After **
The focus is immediately on the first menu item
https://user-images.githubusercontent.com/54366961/177588036-e677d098-0883-42b7-9eec-4642d3d1aafe.mov

### How do I test this code?
1. Check out this branch locally, run `npm i` and `npm run demo` and open http://localhost:3000
2. Turn on screen reader (system preferences > accessibility >  voice over > enable voice over)
3. Use your keyboard to navigate to the myFT button and check that it announces that it's a button and has a collapsed menu
4. Press enter and check that focus is given to the first menu item, and that the menu is announced
5. Check that the button functions as expected both with keyboard and mouse

### Reminder
Have you completed these common tasks? (remove those that don't apply)

- [x] **Manual Testing** checked the expected functionality
- [x] **Guidance for reviewer** communicated expected changes / behaviour
- [x] **Accessibility** checked for screen readers and contrast

### How we will review this PR
Our team uses [conventional comments](https://conventionalcomments.org/) to provide feedback.